### PR TITLE
Refactor bin commands to work locally and in deployment

### DIFF
--- a/bin/bdd
+++ b/bin/bdd
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-bin/features

--- a/bin/behave
+++ b/bin/behave
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-bin/features

--- a/bin/cloud-gov-web
+++ b/bin/cloud-gov-web
@@ -1,13 +1,13 @@
 #!/bin/sh
 
 # Make sure pandoc has what it needs to run
-mkdir -p $HOME/.pandoc/data/
-cat support/abbreviations > $HOME/.pandoc/data/abbreviations
-echo "data-dir: ${HOME}/.pandoc/data/" > pandoc.yml
-pandoc -d pandoc.yml -f markdown -t markdown support/abbreviations
+bin/run-web mkdir -p $HOME/.pandoc/data/
+bin/run-web cat support/abbreviations > $HOME/.pandoc/data/abbreviations
+bin/run-web echo "data-dir: ${HOME}/.pandoc/data/" > pandoc.yml
+bin/run-web pandoc -d pandoc.yml -f markdown -t markdown support/abbreviations
 
 # Run migrations
-python manage.py migrate
+bin/run-web python manage.py migrate
 
 # Run the dev web server
-python manage.py runserver 0.0.0.0:8080
+bin/run-web python manage.py runserver 0.0.0.0:8080

--- a/bin/coverage
+++ b/bin/coverage
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker compose run -it --remove-orphans web coverage report
+bin/run-web coverage report

--- a/bin/exec
+++ b/bin/exec
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker compose exec
+docker compose exec "$@"

--- a/bin/feature_test
+++ b/bin/feature_test
@@ -1,1 +1,1 @@
-docker compose run -it --remove-orphans web coverage run --source='.' manage.py test --pattern '*_test.py' feature_tests
+bin/run-web coverage run --source='.' manage.py test --pattern '*_test.py' feature_tests

--- a/bin/features
+++ b/bin/features
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker compose run -it --remove-orphans web behave
+bin/run-web behave

--- a/bin/manage
+++ b/bin/manage
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker compose run -it --remove-orphans web python manage.py "$@"
+bin/run-web python manage.py "$@"

--- a/bin/run
+++ b/bin/run
@@ -1,3 +1,7 @@
 #!/bin/sh
 
-docker compose run -it --remove-orphans
+if [ -z ${VCAP_APPLICATION+x} ]; then
+  docker compose run -it --remove-orphans "$@"
+else
+  $@
+fi

--- a/bin/run-web
+++ b/bin/run-web
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+bin/run web "$@"

--- a/bin/test
+++ b/bin/test
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker compose run -it --remove-orphans web coverage run --source='.' manage.py test --pattern '*_test.py' $1
+bin/run-web coverage run --source='.' manage.py test --pattern '*_test.py' $1


### PR DESCRIPTION
I wanted to be able to run the `bin/*` commands both locally, to shortcut Docker, and in Cloud.gov. Dev-prod parity!

This turns the `bin/run` command into a conditional that detects if it's in Cloud.gov based on the presence of the VCAP_APPLICATION environment variable.